### PR TITLE
Rinkeby test Network Deprecated by Alchemy. Replace Rinkeby test network with Goerli

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -11,7 +11,7 @@
    defaultNetwork: 'rinkeby',
    networks: {
      hardhat: {},
-     rinkeby: {
+     goerli: {
          url: API_URL_KEY,
          accounts: [`0x${PRIVATE_KEY}`]
      }

--- a/scripts/interact.js
+++ b/scripts/interact.js
@@ -7,7 +7,7 @@ const PRIVATE_KEY = process.env.PRIVATE_KEY; //metamask
 const contract = require('../artifacts/contracts/HelloWorld.sol/HelloWorld.json');
 
 // provider - Alchemy
-const alchemyProvider = new ethers.providers.AlchemyProvider(network="rinkeby", API_KEY);
+const alchemyProvider = new ethers.providers.AlchemyProvider(network="goerli", API_KEY);
 
 // signer - you
 const signer = new ethers.Wallet(PRIVATE_KEY, alchemyProvider);


### PR DESCRIPTION
Since Alchemy has deprecated Rinkeby network and only has support for Goerli. Running the script will give 
"error":{"code":-32000,"message":"ETH_RINKEBY is not supported.

replace rinkeby with goerli in ethers.providers.AlchemyProvider
It follows the course documentation as well.